### PR TITLE
Hero img doesn't overlap navbar now

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -2,7 +2,7 @@
 @tailwind components;
 @tailwind utilities;
 
-
+/* Floating animation for hero section text */
 .floating {
   animation-name: floating;
   animation-duration: 3s;
@@ -12,35 +12,45 @@
   margin-left: 30px;
   margin-top: 5px;
 }
-
 @keyframes floating {
-    0% {
-        transform: translateY(0);
-      }
-      50% {
-        transform: translateY(-30px);
-      }
-      100% {
-        transform: translateY(0);
-      }
- }
+  0% {
+    transform: translateY(0);
+  }
+
+  50% {
+    transform: translateY(-30px);
+  }
+
+  100% {
+    transform: translateY(0);
+  }
+}
+i1{
+  font-size: 40px;
+  cursor: pointer;
+  position: absolute;
+  transform: translate(-0%, -109%);
+}
+header{
+  z-index: 100;
+}
+
 
 ::-webkit-scrollbar {
-    width: 10px;
-  }
-  
-  /* Track */
-  ::-webkit-scrollbar-track {
-    background: black;
-  }
-   
-  /* Handle */
-  ::-webkit-scrollbar-thumb {
-    background:#00BD57; 
-  }
-  
-  /* Handle on hover */
-  ::-webkit-scrollbar-thumb:hover {
-    background:green; 
-  }
+  width: 10px;
+}
 
+/* Track */
+::-webkit-scrollbar-track {
+  background: black;
+}
+
+/* Handle */
+::-webkit-scrollbar-thumb {
+  background: #00BD57;
+}
+
+/* Handle on hover */
+::-webkit-scrollbar-thumb:hover {
+  background: green;
+}


### PR DESCRIPTION

## Closes: #145


## Description of Changes
- I add the z-index for header so that hero sec image doesn't overlap the navbar


## Checklist:

<!--
Mark the checkboxes to indicate completion. Example: 
- [x] My code follows the style guidelines of this project.
-->

- [x ] My code adheres to the established style guidelines of this project.
- [x ] I have conducted a self-review of my code.
- [x ] I have included comments in areas that may be difficult to understand.
- [ ] I have made corresponding updates to the project documentation.
- [x ] My changes have not introduced any new warnings.


## Screenshots

https://github.com/SrijanShovit/carbonops-v2/assets/101205226/db96d540-1e2e-4ad6-a268-25199c451d80


